### PR TITLE
Time and banner image fix

### DIFF
--- a/blog/templates/blog/home.html
+++ b/blog/templates/blog/home.html
@@ -39,6 +39,7 @@
     </div>
 <!--
     Aight end of demo go home, homie
+    What were you smoking when you wrote this?
 -->
 <div class="container-fluid">
     <div class="jumbotron jumbotron-fluid text-center">

--- a/blog/templates/events/events.html
+++ b/blog/templates/events/events.html
@@ -8,7 +8,7 @@
     {% for event in events %}
         <h2 class="jumbotron jumbotron-fluid text-center" style="font-weight: 800;">{{ event.title }}</h2>
         <p class="text-muted text-center"><i class="fa fa-clock-o"></i>Event starts <strong>{{ event.event_date }}</strong></p>
-        <img class="text-center" src="{{ event.banner }}" height="300px">
+        <img class="rounded mx-auto d-block" src="{{ event.banner }}" width="100%">
         <p>
             {{ event.description|safe }}
         </p>

--- a/blog/views.py
+++ b/blog/views.py
@@ -57,7 +57,11 @@ def home(request):
                 p.arrival = i['planned_destairport']
                 p.callsign = i['callsign']
                 p.altitude = i['altitude']
-                delta_time = datetime.datetime.now().replace(tzinfo=dateutil.tz.gettz('Asia/Amman')) - dateutil.parser.parse(i['time_logon'])
+
+                #currentTime = datetime.datetime.utcnow()
+                #planeOnTime = dateutil.parser.parse(i['time_logon']).replace(tzinfo=None)
+
+                delta_time = datetime.datetime.utcnow() - dateutil.parser.parse(i['time_logon']).replace(tzinfo=None)
                 p.time_online = datetime.datetime.strptime(delta_time.__str__(), '%H:%M:%S.%f').strftime('%Hh %Mm %Ss')
                 online_pilots.append(p)
         for i in atc:
@@ -67,7 +71,11 @@ def home(request):
                 a.name = i['realname']
                 a.callsign = i['callsign']
                 a.frequency = (i['frequency']+100000)/1000
-                delta_time = datetime.datetime.now().replace(tzinfo=dateutil.tz.gettz('Asia/Amman')) - dateutil.parser.parse(i['time_logon'])
+
+                #currentTime = datetime.datetime.utcnow()
+                #planeOnTime = dateutil.parser.parse(i['time_logon']).replace(tzinfo=None)
+                
+                delta_time = datetime.datetime.utcnow() - dateutil.parser.parse(i['time_logon']).replace(tzinfo=None)
                 p.time_online = datetime.datetime.strptime(delta_time.__str__(), '%H:%M:%S.%f').strftime('%Hh %Mm %Ss')
                 online_atc.append(a)
     else:


### PR DESCRIPTION
Opa!
I have (I think?) fixed the time error. The table on the home page now displays the correct time for (hopefully) everyone, not just Maher. This was done by comparing the current UTC time to the login time of the user.
I've also made the images on the events page nicer. I made the image centre on the page and 100% width so it's a bit bigger.
One love brother, stay well